### PR TITLE
Initial workflow and README template

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,77 @@
+name: CD
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - config/**
+      - '**/spack.yaml'
+jobs:
+    # FIXME: For now, this modified workflow does not deploy based on changes to the config/** files.
+  # If you change the config/** files, you will need to manually update the manifests you want to deploy.
+  setup-cd:
+    name: Setup CD Info
+    runs-on: ubuntu-latest
+    outputs:
+      manifest: ${{ steps.matrix.outputs.string }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        # Get changed **/spack.yaml files so we can deploy them
+        id: changed-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # v46.0.6
+        with:
+          since_last_remote_commit: true
+          json: true
+          output_dir: .
+          write_output_files: true
+          files: |
+            **/spack.yaml
+
+      - name: Format changed files
+        # We reformat the json list of changed files as list of objects containing the name (the containing folder) and the path (the containing folder AND manifest name)
+        # Eg, ["fre-nctools/spack.yaml", "gh/spack.yaml"] becomes: [{"name": "fre-nctools", "path": "fre-nctools/spack.yaml"}, {"name": "gh", "path": "gh/spack.yaml"}]
+        id: matrix
+        run: |
+          echo "Changed files: ${{ steps.changed-files.outputs.all_changed_files }}"
+
+          echo "All changed files:"
+          cat all_changed_files.json
+          echo ""
+
+          jq -c '[.[] | {name: split("/")[0], path: .}]' all_changed_files.json > matrix.json
+
+          echo "Matrix:"
+          cat matrix.json
+
+          echo "string=$(cat matrix.json)" >> $GITHUB_OUTPUT
+
+  cd:
+    name: CD
+    needs:
+      - setup-cd
+    # A matrix strategy with no elements is considered an error, so we only run this job if there are changed manifests
+    if: needs.setup-cd.outputs.manifest != '[]'
+    strategy:
+      # The failure of install of an unrelated tool shouldn't affect the others
+      fail-fast: false
+      # We don't want to spam the spack instance with install requests - this means that it will seem that
+      # only one of the jobs is being run within the matrix.
+      max-parallel: 1
+      matrix:
+        manifest: ${{ fromJson(needs.setup-cd.outputs.manifest) }}
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v5-model-tools
+    with:
+      model: ${{ matrix.manifest.name }}
+      spack-manifest-path: ${{ matrix.manifest.path }}
+      # This is a non-model deployment repository, so we do not want to tag the deployment or upload to the build database
+      tag-deployment: false
+      upload-to-build-db: false
+    permissions:
+      contents: write
+      # This is due to the entrypoint also handling `on.pull_request` events
+      pull-requests: write
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,128 @@
+# Requires vars.NAME to be set as a variable.
+name: CI
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+      - ready_for_review
+      - converted_to_draft
+    branches:
+      - main
+      - dev
+      - backport/*.*
+    paths:
+      - config/**
+      - '**/spack.yaml'
+  issue_comment:
+    types:
+      - created
+      - edited
+jobs:
+  # FIXME: For now, this modified workflow does not deploy based on changes to the config/** files.
+  # If you change the config/** files, you will need to manually update the manifests you want to deploy.
+  setup-pr:
+    name: Setup PR Info
+    if: >-
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!redeploy'))
+    runs-on: ubuntu-latest
+    outputs:
+      manifest: ${{ steps.matrix.outputs.string }}
+    steps:
+      - name: Get PR HEAD
+        # Get the HEAD of the pull request, which is obtained differently depending on the event (pull_request or issue_comment)
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          head=$(gh pr view \
+            ${{ env.PR_NUMBER }} \
+            --repo ${{ github.repository }} \
+            --json headRefName \
+            --jq '.headRefName'
+          )
+
+          echo "For ${{ github.event_name }} the PR number is ${{ env.PR_NUMBER }} and the head is $head"
+
+          echo "head=$head" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.pr.outputs.head }}
+
+      - name: Get changed files
+        # Get changed **/spack.yaml files so we can deploy them
+        id: changed-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # v46.0.6
+        with:
+          since_last_remote_commit: true
+          json: true
+          output_dir: .
+          write_output_files: true
+          files: |
+            **/spack.yaml
+
+      - name: Format changed files
+        # We reformat the json list of changed files as list of objects containing the name (the containing folder) and the path (the containing folder AND manifest name)
+        # Eg, ["fre-nctools/spack.yaml", "gh/spack.yaml"] becomes: [{"name": "fre-nctools", "path": "fre-nctools/spack.yaml"}, {"name": "gh", "path": "gh/spack.yaml"}]
+        id: matrix
+        run: |
+          echo "Changed files: ${{ steps.changed-files.outputs.all_changed_files }}"
+
+          echo "All changed files:"
+          cat all_changed_files.json
+          echo ""
+
+          jq -c '[.[] | {name: split("/")[0], path: .}]' all_changed_files.json > matrix.json
+
+          echo "Matrix:"
+          cat matrix.json
+
+          echo "string=$(cat matrix.json)" >> $GITHUB_OUTPUT
+
+  pr-ci:
+    name: CI
+    needs:
+      - setup-pr
+    # A matrix strategy with no elements is considered an error, so we only run this job if there are changed manifests
+    if: needs.setup-pr.outputs.manifest != '[]'
+    strategy:
+      # The failure of install of an unrelated tool shouldn't affect the others
+      fail-fast: false
+      # We don't want to spam the spack instance with install requests - this means that it will seem that
+      # only one of the jobs is being run within the matrix.
+      max-parallel: 1
+      matrix:
+        manifest: ${{ fromJson(needs.setup-pr.outputs.manifest) }}
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v5-model-tools
+    with:
+      model: ${{ matrix.manifest.name }}
+      pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
+      spack-manifest-path: ${{ matrix.manifest.path }}
+    permissions:
+      pull-requests: write
+      contents: write
+      statuses: write
+    secrets: inherit
+
+  pr-closed:
+    name: Closed
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    needs:
+      - setup-pr
+    strategy:
+      # The failure of uninstall of an unrelated tool shouldn't affect the others
+      fail-fast: false
+      # We don't want to spam the spack instance with uninstall requests
+      max-parallel: 1
+      matrix:
+        manifest: ${{ fromJson(needs.setup-pr.outputs.manifest) }}
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v5-model-tools
+    with:
+      root-sbd: ${{ matrix.manifest.name }}
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # v46.0.6
         with:
-          since_last_remote_commit: true
+          # If it is a non-closed pull request, we want to get the changed files since the last remote commit, so we don't redeploy files not changed in a commit
+          # If it is a closed PR, or an issue_comment with !redeploy, we want to get the changed files across the whole branch
+          since_last_remote_commit: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
           json: true
           output_dir: .
           write_output_files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,11 @@ jobs:
     needs:
       - setup-pr
     # A matrix strategy with no elements is considered an error, so we only run this job if there are changed manifests
-    if: needs.setup-pr.outputs.manifest != '[]'
+    # and it is either a non-closed pull request or an issue comment that starts with !redeploy
+    if: >-
+      needs.setup-pr.outputs.manifest != '[]' &&
+      ((github.event_name == 'pull_request' && github.event.action != 'closed') ||
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!redeploy')))
     strategy:
       # The failure of install of an unrelated tool shouldn't affect the others
       fail-fast: false
@@ -112,7 +116,9 @@ jobs:
 
   pr-closed:
     name: Closed
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: >-
+      needs.setup-pr.outputs.manifest != '[]' &&
+      github.event_name == 'pull_request' && github.event.action == 'closed'
     needs:
       - setup-pr
     strategy:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
 # software-deployment-template
-A template repository for the deployment of `spack`-based software 
+
+A template repository for the deployment of `spack`-based software
+
+> [!NOTE]
+> Feel free to replace this README with information on the repository once the TODOs have been ticked off.
+
+## Things TODO to get your software deployed
+
+### Settings
+
+#### Repository Settings
+
+Relevant branch protections should be set up on `main` and other important branches.
+
+#### Repository Secrets/Variables
+
+There are a few secrets and variables that must be set at the repository level.
+
+##### Repository Variables
+
+* `CONFIG_VERSIONS_SCHEMA_VERSION`: Version of the [`config/versions.json` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/versions) used in this repository
+* `SPACK_YAML_SCHEMA_VERSION`: Version of the [ACCESS-NRI-style `spack.yaml` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment) used in this repository
+* `RELEASE_DEPLOYMENT_TARGETS`: Space-separated list of deployment targets when doing release deployments. These are often the names of [keys under the `deployment` key of `build-cd`s `config/settings.json`](https://github.com/ACCESS-NRI/build-cd/blob/09cdf100eefc58f06900e8e9145e77b4caf5a39d/config/settings.json#L3), such as `Gadi` or `Setonix`. As noted [below](#environment-secretsvariables), it is the same as the GitHub Environment name. For example: `Gadi Setonix`
+* `PRERELEASE_DEPLOYMENT_TARGETS`: Space-separated list of deployment targets when doing prerelease deployments, similar to the above. For example: `Gadi Setonix` - note the lack of a `Prerelease` specifier!
+
+#### Environment Secrets/Variables
+
+GitHub Environments are sets of variables and secrets that are used specifically to deploy software, and hence have more security requirements for their use.
+
+Currently, we have two Environments per deployment target - one for `Release` and one for `Prerelease`. Our current list of deployment targets and Environments can be found in this [deployment configuration file in `build-cd`](https://github.com/ACCESS-NRI/build-cd/blob/main/config/deployment-environment.json).
+
+In order to deploy to a given deployment target:
+
+* Environments with the name of the deployment target and the type must be created _in this repository_ and have the associated secrets/variables set ([see below](#environment-secrets))
+* There must be a `Prerelease` Environment associated with the `Release` Environment. For example, if we are deploying to `SUPERCOMPUTER`, we require Environments with the names `SUPERCOMPUTER Release`, `SUPERCOMPUTER Prerelease`.
+
+When setting the environment up, remember to require sign off by a member of ACCESS-NRI when deploying as a `Release`.
+
+Regarding the secrets and variables that must be created:
+
+##### Environment Secrets
+
+* `HOST`: The deployment location SSH Host
+* `HOST_DATA`: The deployment location SSH Host for data transfer (may be the same as `HOST`)
+* `SSH_KEY`: A SSH Key that allows access to the above `HOST`/`HOST_DATA`
+* `USER`: A Username to login to the above `HOST`/`HOST_DATA`
+
+##### Environment Variables
+
+* `DEPLOYED_MODULES_DIR`: Directory that will contain the modules created during the installation of the model. This can be virtual modules created by a [`.modulerc` file](https://github.com/ACCESS-NRI/build-cd/tree/main/tools/modules) in the directory.
+* `DEPLOYMENT_TARGET`: Name of the deployment target. It is exported to the deployment target and used for variations in `spack.yaml` build processes - seen most prominently in mutually-exclusive 'when' clauses like `spack.definitions[].when = env['DEPLOYMENT_TARGET'] == 'gadi'`. Also used for logging purposes.
+* `SPACK_INSTALLS_ROOT_LOCATION`: Path to the directory that contains all versions of a deployment of `spack`. For example, if `/some/apps/spack` is the `SPACK_INSTALLS_ROOT_LOCATION`, that directory will contain directories like `0.20`, `0.21`, `0.22`, which in turn contain an install of `spack`, `spack-packages` and `spack-config`
+* `SPACK_YAML_LOCATION`: Path to a directory that will contain the `spack.yaml` from this repository during deployment
+* (Optional) `SPACK_INSTALL_ADDITIONAL_ARGS`: Additional flags outside of `--fresh --fail-fast` to add to the `spack install` command. For advanced users who need to tailor the installation options in their repository.
+
+### File Modifications
+
+#### In `config/versions.json`
+
+* `.spack` must be given a version. For example, it will clone the associated `releases/vVERSION` branch of `ACCESS-NRI/spack` if you give it `VERSION`.
+* `.spack-packages` should also have a CalVer-compliant tag as the version. See the [associated repo](https://github.com/ACCESS-NRI/spack-packages/tags) for a list of available tags.
+
+#### In `spack.yaml`
+
+> [!IMPORTANT]
+> Unlike Model Deployment Repositories (and [the template](https://github.com/ACCESS-NRI/model-deployment-template) they are based on), you can have multiple `spack.yaml` manifests in one repository. Just remember to demarcate them by directory name - eg. `TOOL1/spack.yaml`, `TOOL2/spack.yaml`, etc.

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
+    "spack": "0.22",
+    "spack-packages": "SOME_SPECIFIC_TAG"
+}


### PR DESCRIPTION
## Background

This PR creates a template for spack-based software deployment repositories. 
This is based on the first PR to use this new paradigm of `build-cd`-serviced repositories here: https://github.com/ACCESS-NRI/model-tools/pull/1
This repository is similar to https://github.com/ACCESS-NRI/model-deployment-template

## This PR

In this PR:

- **Add template ci.yml, cd.yml**
- **Add template README**
