### PR TITLE
Infra Update `v7` Guidance

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -63,7 +63,7 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-cd.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v6
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v7
     with:
       model: ${{ matrix.manifest.name }}
       spack-manifest-path: ${{ matrix.manifest.path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-pr.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v6
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
     with:
       model: ${{ matrix.manifest.name }}
       pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
@@ -136,7 +136,7 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-pr.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v6
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v7
     with:
       root-sbd: ${{ matrix.manifest.name }}
     secrets: inherit


### PR DESCRIPTION
References issue ACCESS-NRI/build-cd#320, rollout issue ACCESS-NRI/build-cd#322, and PR ACCESS-NRI/build-cd#231

> [!NOTE]
> SPECIAL NOTE FOR THIS REPOSITORY - this repository doesn't currently have a notion of linked configuration repositories as a normal MDR would. Therefore, the `!update-configs` command is not enabled in `ci-command.yml`. Furthermore, the `!redeploy` logic is different from other MDRs, so it isn't able to be moved out of the `ci.yml` at this time

> [!IMPORTANT]
> This PR is a major update to the deployment infrastructure.

## Background

It has been a bit of pain for users to have to open up model configs PRs to test out a given Prerelease build. This PR adds a feature which links Model Deployment Repositories (MDRs) to their associated Configs repositories, allowing users to update configurations with prerelease builds automatically via a `!update-configs` command. Configuration of this new command is done in a `config/auto-configs-pr.json` configuration file.

However, since this is a software deployment repository, which doesn't have a notion of configs, it is not enabled in this repo. Furthermore, the file reorganisation isn't planned for this style of repository due to the `ci.yml` pre-processing of the only comment command available: `!redeploy`.
