### PR TITLE
Update Guidance for `v8` - `spack v1` Migration

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,7 +66,7 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-cd.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v7
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ matrix.manifest.name }}
       spack-manifest-path: ${{ matrix.manifest.path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-pr.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ matrix.manifest.name }}
       pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
@@ -139,7 +139,7 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-pr.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
     with:
-      root-sbd: ${{ matrix.manifest.name }}
+      spack-manifest-path: ${{ matrix.manifest.path }}
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ There are a few secrets and variables that must be set at the repository level.
 
 ##### Repository Variables
 
-* `CONFIG_VERSIONS_SCHEMA_VERSION`: Version of the [`config/versions.json` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/versions) used in this repository
-* `SPACK_YAML_SCHEMA_VERSION`: Version of the [ACCESS-NRI-style `spack.yaml` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment) used in this repository
 * `RELEASE_DEPLOYMENT_TARGETS`: Space-separated list of deployment targets when doing release deployments. These are often the names of [keys under the `deployment` key of `build-cd`s `config/settings.json`](https://github.com/ACCESS-NRI/build-cd/blob/09cdf100eefc58f06900e8e9145e77b4caf5a39d/config/settings.json#L3), such as `Gadi` or `Setonix`. As noted [below](#environment-secretsvariables), it is the same as the GitHub Environment name. For example: `Gadi Setonix`
 * `PRERELEASE_DEPLOYMENT_TARGETS`: Space-separated list of deployment targets when doing prerelease deployments, similar to the above. For example: `Gadi Setonix` - note the lack of a `Prerelease` specifier!
 
@@ -64,7 +62,7 @@ Regarding the secrets and variables that must be created:
 #### In `config/versions.json`
 
 * `.spack` must be given a version. For example, it will clone the associated `releases/vVERSION` branch of `ACCESS-NRI/spack` if you give it `VERSION`.
-* `.spack-packages` should also have a CalVer-compliant tag as the version. See the [associated repo](https://github.com/ACCESS-NRI/spack-packages/tags) for a list of available tags.
+* `.access-spack-packages` should also have a CalVer-compliant tag as the version. See the [associated repo](https://github.com/ACCESS-NRI/spack-packages/tags) for a list of available tags.
 
 #### In `spack.yaml`
 

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
-    "spack": "0.22",
-    "spack-packages": "SOME_SPECIFIC_TAG"
+    "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
+    "spack": "1.1",
+    "access-spack-packages": "SOME_SPECIFIC_TAG"
 }


### PR DESCRIPTION
References https://github.com/ACCESS-NRI/build-cd/pull/326
Closes #36

## Background

This PR updates `software-deployment-template` guidance for `build-cd v8` - the `spack v1.X` migration. It includes:

* The new `spack.yaml` reserved definitions `.spack.definitions[].{_name|_version}`
* The new optional `config/versions.json` field `.custom-scopes`, to pass in high-precendence spack configuration
* Updated guidance on `spack.specs`

## The PR

- **Update workflow, manifest, config for v8**
- **Update README guidance for v8**
